### PR TITLE
#63 Update workflow to create PR instead of pushing directly to main'

### DIFF
--- a/.github/workflows/update_projects.yml
+++ b/.github/workflows/update_projects.yml
@@ -2,14 +2,16 @@ name: Weekly Project Update
 
 on:
   schedule:
-    - cron: '30 18 * * 5' # 18:30 UTC Friday = 00:00 IST Saturday
-  workflow_dispatch: # Allow manual triggering
+    # 18:30 UTC Friday = 00:00 IST Saturday
+    - cron: '30 18 * * 5'
+  workflow_dispatch:
 
 jobs:
   update-projects:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Need write permission to commit
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -18,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |
@@ -28,15 +30,12 @@ jobs:
       - name: Run update script
         run: python update_projects.py
 
-      - name: Commit and push changes
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add assets/data/last_updated.json
-          # Only commit if there are changes
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "Weekly project update"
-            git push
-          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "weekly project update"
+          title: "Weekly Project Update"
+          body: "This PR updates the project data via the automated schedule."
+          branch: "automated-project-update"
+          base: "main"
+          delete-branch: true


### PR DESCRIPTION
Updates the Github Workflow for `update_projects.yml`

Originally the workflow was supposed to push changes directly to main but due to the problems faced and mentioned in issue #63 _(`main` -> `main` merge denied due to branch protection)_

Fix: Added a Github action to perform the update and create a pull request, every week I just need to just hit merge pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development environment configuration in automated workflows.
  * Enhanced pull request automation workflow permissions.

* **Refactor**
  * Optimized automated workflow steps for improved efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->